### PR TITLE
prefer Kotlin distrib from IDE, remove unnecessary buildSearchableOptions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,10 +58,6 @@ tasks {
         }
     }
 
-    buildSearchableOptions {
-        enabled = false
-    }
-
     patchPluginXml {
         pluginDescription.set(properties("pluginDescription"))
         version.set(properties("pluginVersion"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,9 @@ intellij {
 }
 
 dependencies {
-    implementation("com.beust:klaxon:5.6")
+    implementation("com.beust:klaxon:5.6")  {
+        exclude(group = "org.jetbrains.kotlin") // prefer Kotlin distribution offered by IDE
+    }
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
 }
 
@@ -54,6 +56,10 @@ tasks {
                 "^[0-9,.v-]+(-r)?$".toRegex().matches(candidate.version)
             ).not()
         }
+    }
+
+    buildSearchableOptions {
+        enabled = false
     }
 
     patchPluginXml {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ javaVersion = 11
 kotlinJvmTarget = 11
 
 kotlin.code.style=official
+kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
- I think we can use the Kotlin distribution that comes with the running IDE, as described here: https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library. It will reduce plugin's size since we no longer ship Kotlin libs. I tested on my machine: the new plugin size is about 184KB, and I was able to display emojis from the project's readme file.
- Since the plugin does not implement settings, we can disable `buildSearchableOptions`. It will improve build time and remove an unnecessary jar file from the plugin archive